### PR TITLE
Hjepa wall integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "hjepa"]
+	path = hjepa
+	url = git@github.com:vladisai/HJEPA.git

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # HIQL: Offline Goal-Conditioned RL with Latent States as Actions
 
-## NYU cluster setup
+## Git clone command
+We add the recursive command to clone the submodules:
+```
+git clone --recurse-submodules git@github.com:vladisai/HIQL.git
+```
 
+## NYU cluster setup
 This is how I set it up:
 ```
 conda create --name hiql python=3.9

--- a/src/envs/wall/configs/no_fixed_wall.yaml
+++ b/src/envs/wall/configs/no_fixed_wall.yaml
@@ -1,0 +1,56 @@
+n_steps: &n_steps 17
+val_n_steps: *n_steps
+
+wall_config:
+  action_bias_only: false
+  action_noise: 1
+  action_angle_noise: 0.2
+  action_step_mean: 1.0
+  action_step_std: 0.4
+  action_lower_bd: 0.2
+  action_upper_bd: 1.8
+  action_param_xy: true
+  batch_size: 64
+  device: cuda
+  dot_std: 1.3
+  border_wall_loc: 5
+  fix_wall_batch_k: null
+  fix_wall: false
+  fix_door_location: 10
+  fix_wall_location: 32
+  exclude_wall_train: ''
+  exclude_door_train: ''
+  only_wall_val: ''
+  only_door_val: ''
+  wall_padding: 20
+  door_padding: 10
+  wall_width: 3
+  door_space: 4
+  num_train_layouts: -1
+  cross_wall_rate: 0.08
+  expert_cross_wall_rate: 0
+  img_size: 65
+  max_step: 1
+  n_steps: *n_steps
+  n_steps_reduce_factor: 1
+  noise: 0
+  normalize: true
+  size: 20000
+  val_size: 10000
+  static_noise: 0
+  static_noise_speed: 0
+  structured_noise: false
+  structured_noise_path: /tmp/cifar10
+  train: true
+  zero_action: false
+  repeat_actions: 1
+  normalizer_hardset: false
+eval_cfg:
+  n_envs: 300
+  seed: 42
+  level: "normal" # normal, easy
+  sample_y_min: 32
+  sample_y_max: 60
+  padding: 1
+  n_steps: 32
+  error_threshold: 1

--- a/src/envs/wall/wall_example.py
+++ b/src/envs/wall/wall_example.py
@@ -1,0 +1,73 @@
+import sys
+import os
+import yaml
+from dataclasses import dataclass, fields, asdict
+from typing import Optional
+from types import SimpleNamespace
+import torch
+
+# Add the 'hjepa' directory to the Python path. Change it to your path
+sys.path.append("/scratch/wz1232/HIQL/hjepa")
+
+from data.wall.wall import WallDataset, WallDatasetConfig
+
+
+def dict_to_namespace(d):
+    """
+    # Function to convert dictionary to SimpleNamespace
+    """
+    for key, value in d.items():
+        if isinstance(value, dict):
+            d[key] = dict_to_namespace(value)  # Recursively handle nested dictionaries
+    return SimpleNamespace(**d)
+
+
+def update_config_from_yaml(config_class, yaml_data):
+    """
+    Create an instance of `config_class` using default values, but override
+    fields with those provided in `yaml_data`.
+    """
+    config_field_names = {f.name for f in fields(config_class)}
+    relevant_yaml_data = {
+        key: value for key, value in yaml_data.items() if key in config_field_names
+    }
+    return config_class(**relevant_yaml_data)
+
+
+# yaml file for HJEPA experiment using random exploratory dataset
+data_yaml_path = "/scratch/wz1232/HIQL/src/envs/wall/configs/no_fixed_wall.yaml"
+
+# Load the YAML configuration from a file (or string)
+with open(data_yaml_path, "r") as file:
+    yaml_data = yaml.safe_load(file)
+
+# Create offline dataset
+data_yaml_data = yaml_data["wall_config"]
+data_config = update_config_from_yaml(WallDatasetConfig, data_yaml_data)
+ds = WallDataset(data_config)
+states, locations, actions, bias_angle, wall_x, door_y = ds[
+    0
+]  # All the samples are normalized
+
+# Create evaluation envs
+eval_yaml_data = yaml_data["eval_cfg"]
+eval_config = dict_to_namespace(eval_yaml_data)
+
+from planning.wall.utils import construct_planning_envs
+
+# NORMALIZED obs and target_obs by default (ds.normalizer.normalize_state(obs))
+envs, obs, targets, target_obs, wall_locs, door_locs = construct_planning_envs(
+    config=eval_config,
+    wall_config=data_config,
+    cross_wall=True,
+    n_envs=eval_config.n_envs,
+    normalizer=ds.normalizer,
+)
+
+# Then you can execute your policy / planner to get action and perform on the envs...
+# NOTE: We assume that the policy outputs NORMALIZED actions. you want to UNNORMALIZE it before doing env.step(a)
+
+# finally. figure out which trials are successful by looking at whether dot_position and target l2 distance < threshold
+locations = torch.stack([e.dot_position for e in envs])
+mse = (locations - targets).pow(2).mean(dim=1)
+successes = (mse < eval_config.error_threshold).float()


### PR DESCRIPTION
Changes:

1) Integrated HJEPA codebase as submodule. To clone this repo, you must do `git clone --recurse-submodules git@github.com:vladisai/HIQL.git` now.
I think integrating HJEPA as a submodule is a good approach since it keeps things up-to-date. Otherwise we have to manually copy any later changes from HJEPA to here. If you need to modify certain datasets / env to make it compatible with the HIQL API, I suggest you to just create wrapper classes in /src/envs/wall/

2) Implemented [mini example file](https://github.com/vladisai/HIQL/blob/hjepa_wall_integration/src/envs/wall/wall_example.py) to demonstrate how to create the wall offline dataset, and construct environments for testing. These are exactly the settings I used for the HJEPA experiments.

The offline dataset items are normalized (HJEPA normalizer [code](https://github.com/vladisai/HJEPA/blob/main/data/normalizer.py))
The `obs` and `target_obs` created [here](https://github.com/vladisai/HIQL/blob/hjepa_wall_integration/src/envs/wall/wall_example.py#L59) are already normalized. So you can directly feed it into your model.

However - one thing to be careful is that the predicted actions from the policy network is probably normalized (since the offline data it was trained on was normalized), so you have to take care to unnormalize it before feeding it into the environment.

